### PR TITLE
Update the special characters list in order to accept a wider list of characters for passwords

### DIFF
--- a/app/src/main/java/foundation/icon/iconex/MyConstants.java
+++ b/app/src/main/java/foundation/icon/iconex/MyConstants.java
@@ -68,7 +68,7 @@ public class MyConstants {
     public static final int NETWORK_TEST = 1;
     public static final int NETWORK_DEV = 2;
 
-    public static final String PATTERN_PASSWORD = "^(?=.*\\d)(?=.*[a-zA-Z])(?=.*[!@#$%^&*()_+{}:<>?]).{8,}$";
+    public static final String PATTERN_PASSWORD = "^(?=.*\\d)(?=.*[a-zA-Z])(?=.*[?!:\.,%+-/*<>{}\(\)\[\]`\"'~_^\\|@#$&]).{8,}$";
 
     public enum CoinType {
         ICX,


### PR DESCRIPTION
As discussed in the [PR#12 from iconex_chrome_extension](https://github.com/icon-project/iconex_chrome_extension/pull/12) repository, I'd suggest to update the special characters list in order to let people use a wider range of special characters.
